### PR TITLE
Case law formatting

### DIFF
--- a/03_caselaw.ipynb
+++ b/03_caselaw.ipynb
@@ -247,11 +247,14 @@
     "    # Step-by-step:\n",
     "    court = case[\"court\"]\n",
     "    court_name = court[\"name\"]\n",
-    "    print(\"court name:\", court_name)\n",
+    "    print(\"Court name:\", court_name)\n",
     "\n",
-    "    # one giant step\n",
+    "    # One giant step:\n",
     "    attorneys = case[\"casebody\"][\"data\"][\"attorneys\"]\n",
-    "    print(\"attorneys:\", attorneys)"
+    "    print(\"Attorneys:\", attorneys)\n",
+    "    \n",
+    "    # Extra linebreak:\n",
+    "    print()"
    ]
   },
   {
@@ -274,7 +277,7 @@
    },
    "outputs": [],
    "source": [
-    "URL = \"https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=1\"\n",
+    "URL = \"https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=3\"\n",
     "data = requests.get(URL).json()\n",
     "\n",
     "cases = data[\"results\"]\n",
@@ -289,7 +292,7 @@
    "source": [
     "## Working with Lists\n",
     "\n",
-    "Each case in the data set contains a list of one or more opinions. These lists are located quite deep in the data structure, in ` case[\"casebody\"][\"data\"][\"opinions\"]`. These levels are somewhat like directories in a file tree, and can be seen when browsing the [web interface](https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=1\").\n",
+    "Each case in the data set contains a list of one or more opinions. These lists are located quite deep in the data structure, in ` case[\"casebody\"][\"data\"][\"opinions\"]`. These levels are somewhat like directories in a file tree, and can be seen when browsing the [web interface](https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=3\").\n",
     "\n",
     "We can look at some of the data for each opinion:"
    ]
@@ -307,7 +310,8 @@
     "    print(\"Court:\", case[\"court\"][\"name\"])\n",
     "    opinions = case[\"casebody\"][\"data\"][\"opinions\"]\n",
     "    for opinion in opinions:\n",
-    "        print(\" opinion author:\", opinion[\"author\"])"
+    "        print(\"  Opinion author:\", opinion[\"author\"])\n",
+    "    print()"
    ]
   },
   {

--- a/solutions/solutions_03-04.ipynb
+++ b/solutions/solutions_03-04.ipynb
@@ -24,14 +24,17 @@
      "output_type": "stream",
      "text": [
       "Case name: Federal Insurance v. Lexington Insurance\n",
-      "docket number: No. 1—09—3296\n",
-      "decision date: 2011-01-03\n",
+      "Docket number: No. 1—09—3296\n",
+      "Decision date: 2011-01-03\n",
+      "\n",
       "Case name: People v. Connolly\n",
-      "docket number: No. 3—08—1027\n",
-      "decision date: 2011-01-04\n",
+      "Docket number: No. 3—08—1027\n",
+      "Decision date: 2011-01-04\n",
+      "\n",
       "Case name: Eck v. Greer\n",
-      "docket number: No. 5—10—0353\n",
-      "decision date: 2011-01-06\n"
+      "Docket number: No. 5—10—0353\n",
+      "Decision date: 2011-01-06\n",
+      "\n"
      ]
     }
    ],
@@ -46,8 +49,9 @@
     "for case in cases:\n",
     "    print(\"Case name:\", case[\"name_abbreviation\"])\n",
     "    #your code here\n",
-    "    print(\"docket number:\", case[\"docket_number\"])\n",
-    "    print(\"decision date:\", case[\"decision_date\"])"
+    "    print(\"Docket number:\", case[\"docket_number\"])\n",
+    "    print(\"Decision date:\", case[\"decision_date\"])\n",
+    "    print()"
    ]
   },
   {
@@ -75,13 +79,36 @@
       "Opinion filed January 3, 2011.\n",
       "Tressler, LLP, of Chicago (Todd S. Schenk and Amber C. Coisman, of counsel), for appellant.\n",
       "Donohue Brown Mathewson & Smyth LLC, of Chicago (Norman J. Barry, Jr., Karen Kies DeGrand, and Christopher J. Rados, of counsel), for appellee.\n",
-      " Attorney: Tressler, LLP, of Chicago (Todd S. Schenk and Amber C. Coisman, of counsel), for appellant.\n",
-      " Attorney: Donohue Brown Mathewson & Smyth LLC, of Chicago (Norman J. Barry, Jr., Karen Kies DeGrand, and Christopher J. Rados, of counsel), for appellee.\n"
+      "Attorney: Tressler, LLP, of Chicago (Todd S. Schenk and Amber C. Coisman, of counsel), for appellant.\n",
+      "Attorney: Donohue Brown Mathewson & Smyth LLC, of Chicago (Norman J. Barry, Jr., Karen Kies DeGrand, and Christopher J. Rados, of counsel), for appellee.\n",
+      "\n",
+      "Case name: People v. Connolly\n",
+      "Head matter: THE PEOPLE OF THE STATE OF ILLINOIS, Plaintiff-Appellee, v. PHILLIP CONNOLLY, Defendant-Appellant.\n",
+      "Third District\n",
+      "No. 3—08—1027\n",
+      "Opinion filed January 4, 2011.\n",
+      "Dan W Evers, of State Appellate Defender’s Office, of Mount Vernon, for appellant.\n",
+      "James Glasgow, State’s Attorney, of Joliet (Terry A. Mertel, of State’s Attorneys Appellate Prosecutor’s Office, of counsel), for the People.\n",
+      "Attorney: Dan W Evers, of State Appellate Defender’s Office, of Mount Vernon, for appellant.\n",
+      "Attorney: James Glasgow, State’s Attorney, of Joliet (Terry A. Mertel, of State’s Attorneys Appellate Prosecutor’s Office, of counsel), for the People.\n",
+      "\n",
+      "Case name: Eck v. Greer\n",
+      "Head matter: In re GUARDIANSHIP OF A.G.G., a Minor (Victor Eck, Petitioner-Appellant, v. Jennifer Greer, Respondent-Appellee).\n",
+      "Fifth District\n",
+      "No. 5—10—0353\n",
+      "Opinion filed January 6, 2011.\n",
+      "Susan Burger, of Jonesboro, for appellant.\n",
+      "Ann P. Coward and Sandi Gordon, both of Land of Lincoln Legal Assistance Foundation, Inc., of Carbondale, for appellee.\n",
+      "Eugenia C. Hunter, of Carbondale, guardian ad litem.\n",
+      "Attorney: Susan Burger, of Jonesboro, for appellant.\n",
+      "Attorney: Ann P. Coward and Sandi Gordon, both of Land of Lincoln Legal Assistance Foundation, Inc., of Carbondale, for appellee.\n",
+      "Attorney: Eugenia C. Hunter, of Carbondale, guardian ad litem.\n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "URL = \"https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=1\"\n",
+    "URL = \"https://api.case.law/v1/cases/?jurisdiction=ill&full_case=true&decision_date_min=2011-01-01&page_size=3\"\n",
     "data = requests.get(URL).json()\n",
     "\n",
     "cases = data[\"results\"]\n",
@@ -91,7 +118,8 @@
     "    print(\"Head matter:\", case[\"casebody\"][\"data\"][\"head_matter\"])\n",
     "    attorneys = case[\"casebody\"][\"data\"][\"attorneys\"]\n",
     "    for attorney in attorneys:\n",
-    "        print(\" Attorney:\", attorney)"
+    "        print(\"Attorney:\", attorney)\n",
+    "    print()"
    ]
   },
   {


### PR DESCRIPTION
 Case law: Tweak output formatting

- Increase page_size from 1 to 3 in some examples, to justify the use of loops
- Consistent capitalization (uppercase first) for all the headings
- Add extra linebreak between the different cases
- Include output in solution